### PR TITLE
Adding packaging to dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ keywords =
     measurement
     acquisition
     zmq
+    packaging
 url = https://github.com/casabre/pyvisa-proxy
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
closes #20 

It seems that packaging module is not provided on every system and also not requested by pyvisa. Thus, added also to the dependencies.